### PR TITLE
Corrected single quote string declaration

### DIFF
--- a/1_variables_and_data_types/variablesDataTypes.md
+++ b/1_variables_and_data_types/variablesDataTypes.md
@@ -41,7 +41,7 @@ There are 3 ways of representing a string:
 We can use Single Quote or Double Quote if we just want to statically display it.
 
 ```js
-const singleQuote = "Hello";
+const singleQuote = 'Hello';
 const doubleQuote = "Hello";
 ```
 


### PR DESCRIPTION
@ShubhamSKadam 

Single Quote string declaration is incorrect
Current:
```javascript
const singleQuete = "String";
```

Corrected as

```javascript
const singleQuete = 'String';
```